### PR TITLE
Corrected typo on '$ python -m nbpresent.install --enable'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ python -m nbbrowserpdf.install
 
 Enable the extension for every notebook launch:
 ```shell
-python -m nbpresent.install --enable
+python -m nbbrowserpdf.install --enable
 ```
 
 Installing with `conda` will handle the installation and enabling (in user


### PR DESCRIPTION
Corrected typo : `python -m nbpresent.install --enable` → `$ python -m nbbrowserpdf.install --enable` : the module is *not* [nbpresent](https://github.com/Anaconda-Platform/nbpresent/) but [nbbrowserpdf](https://github.com/Anaconda-Platform/nbbrowserpdf/).